### PR TITLE
Bump docker image and use cargo-release in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.61.0
+FROM rust:1.64.0
 
 WORKDIR /code
 

--- a/deploy/build
+++ b/deploy/build
@@ -39,13 +39,7 @@ if [[ "$DRONE_TAG" != "$positional_derive_version" ]]; then
 fi
 
 git checkout .
+
+cargo install cargo-release --version "0.23.*"
 cargo login "$CARGO_AUTH_KEY"
-cargo publish -p positional_derive
-
-while [ "$DRONE_TAG" != "$current_remote_version" ]
-do
-  current_remote_version=$(curl "https://crates.io/api/v1/crates/positional_derive/$DRONE_TAG" -s | jq -r '.version .num')
-  sleep 3
-done
-
-cargo publish -p positional
+cargo release publish --execute --no-confirm --allow-branch "*" --workspace --all-features

--- a/positional/src/error.rs
+++ b/positional/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 pub type PositionalResult<T> = Result<T, PositionalError>;
 
 /// library error type
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum PositionalError {
     #[error("Unable to parse the file")]
     UnparsableFile,

--- a/positional_derive/src/analyze/field_alignment.rs
+++ b/positional_derive/src/analyze/field_alignment.rs
@@ -4,7 +4,7 @@ use quote::ToTokens;
 use quote::TokenStreamExt;
 use std::str::FromStr;
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum FieldAlignment {
     Left,
     Right,


### PR DESCRIPTION
This PR tries to fix the build step.

The current problem we have is that even if we wait for `positional_derive` to be present on crates.io, it may still not be present in the index and publish `positional` might fail. To fix this @WilliamVenner suggested we use `cargo-release` which is available from rust 1.64 onwards.

So I updated the Docker image to 1.64 and changed the build script to use `cargo-release`.

I am not sure that changing the image version in the Dockerfile is going to influence the image version during the build step, but I don't know where else I could change the image version that's run...