### PR TITLE
Expose PositionalError type instead of opaque Box<dyn Error>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### [Next]
+- expose PositionalResult<T> instead of Box<dyn Error>
+- improved macro hygiene and added regression tests
 
 ### [0.3.0]
 

--- a/positional/benches/enum.rs
+++ b/positional/benches/enum.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use criterion::{criterion_group, criterion_main, Criterion};
 use fake::{Fake, Faker};
-use positional::*;
+use positional::{FromPositionalRow, ToPositionalRow};
 
 #[derive(FromPositionalRow, ToPositionalRow, Debug)]
 struct Data {

--- a/positional/benches/serde.rs
+++ b/positional/benches/serde.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use criterion::{criterion_group, criterion_main, Criterion};
 use fake::{Dummy, Fake, Faker};
-use positional::*;
+use positional::{FromPositionalRow, Reader, ToPositionalField, ToPositionalRow, Writer};
 use std::str::FromStr;
 
 #[derive(ToPositionalRow, FromPositionalRow, Dummy, Debug)]

--- a/positional/benches/write_to_file.rs
+++ b/positional/benches/write_to_file.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use criterion::{criterion_group, criterion_main, Criterion};
 use fake::{Dummy, Fake, Faker};
-use positional::*;
+use positional::{FromPositionalRow, ToPositionalRow};
 use std::fs::File;
 use std::io::{LineWriter, Write};
 

--- a/positional/examples/test.rs
+++ b/positional/examples/test.rs
@@ -1,4 +1,4 @@
-use positional::*;
+use positional::ToPositionalRow;
 
 #[derive(ToPositionalRow)]
 struct Data {

--- a/positional/examples/write.rs
+++ b/positional/examples/write.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use fake::{Dummy, Fake, Faker};
-use positional::*;
+use positional::{FromPositionalRow, ToPositionalRow, Writer};
 
 #[derive(ToPositionalRow, FromPositionalRow, Dummy, Debug)]
 struct Data {

--- a/positional/src/error.rs
+++ b/positional/src/error.rs
@@ -16,4 +16,7 @@ pub enum PositionalError {
         "Given row `{1}` has length {}; expected length: {0}", .1.len()
     )]
     RowSizeError(usize, String),
+
+    #[error("Parsing field `{field}` in row `{row}` failed.")]
+    ParsingFailed { field: String, row: String },
 }

--- a/positional/src/lib.rs
+++ b/positional/src/lib.rs
@@ -12,7 +12,7 @@
 //! If you have the data in memory and want to serialize the struct in a positional file
 //! you need to annotate the struct with the `ToPositionalRow` derive.
 //! ```
-//! use positional::*;
+//! use positional::ToPositionalRow;
 //!
 //! #[derive(ToPositionalRow)]
 //! struct RowData {
@@ -33,7 +33,7 @@
 //!
 //! If you are parsing a file you can use the `FromPositionalRow` derive
 //! ```
-//! use positional::*;
+//! use positional::FromPositionalRow;
 //!
 //! #[derive(FromPositionalRow, PartialEq, Debug)]
 //! struct RowData {
@@ -83,7 +83,7 @@
 //! You can use an enum to represent all rows inside a file.
 //!
 //! ```
-//! use positional::*;
+//! use positional::{FromPositionalRow, ToPositionalRow};
 //!
 //! #[derive(FromPositionalRow, ToPositionalRow)]
 //! enum Rows {

--- a/positional/src/parsed_field.rs
+++ b/positional/src/parsed_field.rs
@@ -26,12 +26,14 @@ impl<'s> PositionalParsedField<'s> {
         // we don't take into consideration the empty string (or generally an out of bound string)
         // because we are already checking for string correctness in the main `from_positional_row`
         // function
+
         let raw_value = self
             .row
             .chars()
             .skip(self.offset)
             .take(self.size)
             .collect::<String>();
+
         if self.left_aligned {
             raw_value.trim_end_matches(self.filler).to_string()
         } else {

--- a/positional/src/row.rs
+++ b/positional/src/row.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use crate::PositionalResult;
 
 /// implement this trait to mark something as serializable into a row of a positional file
 pub trait ToPositionalRow {
@@ -7,7 +7,7 @@ pub trait ToPositionalRow {
 
 /// implement this trait to mark something as parsable from a row of a positional file
 pub trait FromPositionalRow {
-    fn from_positional_row(row: &str) -> Result<Self, Box<dyn Error>>
+    fn from_positional_row(row: &str) -> PositionalResult<Self>
     where
         Self: Sized;
 }

--- a/positional/tests/external_types.rs
+++ b/positional/tests/external_types.rs
@@ -30,7 +30,7 @@ impl Data {
 fn simple() {
     let rows = vec![Data::new(
         "the name".to_string(),
-        NaiveDate::from_ymd(2022, 1, 1),
+        NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
     )];
     let positional_file: Writer<Data> = Writer::new(rows);
     assert_eq!(

--- a/positional/tests/external_types.rs
+++ b/positional/tests/external_types.rs
@@ -1,5 +1,5 @@
 use chrono::NaiveDate;
-use positional::*;
+use positional::{ToPositionalField, ToPositionalRow, Writer};
 
 struct Date(NaiveDate);
 

--- a/positional/tests/name_clashes.rs
+++ b/positional/tests/name_clashes.rs
@@ -1,3 +1,5 @@
+// Force name clashes to make sure the macros generate code with fully qualified imports.
+
 pub trait ToPositionalField {}
 pub trait ToPositionalRow {}
 pub trait FromPositionalRow {}
@@ -12,6 +14,18 @@ struct Data {
     age: i32,
     #[field(size = 20)]
     address: String,
+}
+
+impl Data {
+    #[allow(dead_code)]
+    fn from_positional_row(_: &str) -> Self {
+        unreachable!()
+    }
+
+    #[allow(dead_code)]
+    fn to_positional_row(self) -> String {
+        unreachable!()
+    }
 }
 
 impl Data {

--- a/positional/tests/name_clashes.rs
+++ b/positional/tests/name_clashes.rs
@@ -1,0 +1,42 @@
+pub trait ToPositionalField {}
+pub trait ToPositionalRow {}
+pub trait FromPositionalRow {}
+
+mod positional {}
+
+#[derive(::positional::ToPositionalRow, ::positional::FromPositionalRow, PartialEq, Debug)]
+struct Data {
+    #[field(size = 5)]
+    name: String,
+    #[field(size = 5, filler = '-', align = "right")]
+    age: i32,
+    #[field(size = 20)]
+    address: String,
+}
+
+impl Data {
+    pub fn new(name: impl ToString, age: i32, address: impl ToString) -> Self {
+        Self {
+            name: name.to_string(),
+            age,
+            address: address.to_string(),
+        }
+    }
+}
+
+#[test]
+fn parse() {
+    let row =
+        ::positional::FromPositionalRow::from_positional_row("1    ---10the address is this ")
+            .expect("error converting from positional row");
+    assert_eq!(Data::new(1, 10, "the address is this"), row);
+}
+
+#[test]
+fn ser_de() {
+    let data = Data::new(1, 100, "the address is this");
+    let row = ::positional::ToPositionalRow::to_positional_row(&data);
+    let original_data: Data = ::positional::FromPositionalRow::from_positional_row(&row)
+        .expect("error converting from positional row");
+    assert_eq!(original_data, data);
+}

--- a/positional/tests/parse_row.rs
+++ b/positional/tests/parse_row.rs
@@ -1,4 +1,4 @@
-use positional::*;
+use positional::{FromPositionalRow, PositionalError, ToPositionalRow};
 
 #[derive(ToPositionalRow, FromPositionalRow, PartialEq, Debug)]
 struct Data {
@@ -39,10 +39,7 @@ fn ser_de() {
 #[test]
 fn empty_string() {
     let row = <Data as FromPositionalRow>::from_positional_row("");
-    assert_eq!(
-        row.err().map(|e| e.to_string()),
-        Some("Given row `` has length 0; expected length: 30".to_string())
-    );
+    assert_eq!(row, Err(PositionalError::RowSizeError(30, "".to_string())));
 }
 
 #[test]
@@ -50,12 +47,8 @@ fn string_smaller_than_field_definition() {
     let row_content = "1    ---10";
     let row = Data::from_positional_row(row_content);
     assert_eq!(
-        row.err().map(|e| e.to_string()),
-        Some(format!(
-            "Given row `{0}` has length {1}; expected length: 30",
-            row_content,
-            row_content.len()
-        ))
+        row,
+        Err(PositionalError::RowSizeError(30, row_content.to_string()))
     );
 }
 

--- a/positional/tests/positional_file.rs
+++ b/positional/tests/positional_file.rs
@@ -1,4 +1,4 @@
-use positional::*;
+use positional::{ToPositionalRow, Writer};
 use std::fmt::{Display, Formatter};
 use std::num::ParseIntError;
 use std::str::FromStr;

--- a/positional/tests/positional_file_with_counter.rs
+++ b/positional/tests/positional_file_with_counter.rs
@@ -1,4 +1,4 @@
-use positional::*;
+use positional::{ToPositionalRow, Writer};
 
 #[derive(ToPositionalRow)]
 struct Data {

--- a/positional_derive/src/codegen/from_enum.rs
+++ b/positional_derive/src/codegen/from_enum.rs
@@ -10,7 +10,7 @@ pub fn codegen_enum(ir: EnumIr, impl_block_type: ImplBlockType) -> Rust {
         ImplBlockType::From => {
             let variants_stream = create_variants_for_from_positional_row(ir.variants.as_slice());
             quote! {
-                impl FromPositionalRow for #container_identity {
+                impl ::positional::FromPositionalRow for #container_identity {
                     fn from_positional_row(row: &str) -> ::positional::PositionalResult<Self> {
                         #(#variants_stream)*
                         Err(::positional::PositionalError::UnparsableFile)
@@ -21,7 +21,7 @@ pub fn codegen_enum(ir: EnumIr, impl_block_type: ImplBlockType) -> Rust {
         ImplBlockType::To => {
             let variants_stream = create_variants_for_to_positional_row(ir.variants.as_slice());
             quote! {
-                impl ToPositionalRow for #container_identity {
+                impl ::positional::ToPositionalRow for #container_identity {
                     fn to_positional_row(&self) -> String {
                         match self {
                             #(#variants_stream),*

--- a/positional_derive/src/codegen/from_enum.rs
+++ b/positional_derive/src/codegen/from_enum.rs
@@ -11,9 +11,9 @@ pub fn codegen_enum(ir: EnumIr, impl_block_type: ImplBlockType) -> Rust {
             let variants_stream = create_variants_for_from_positional_row(ir.variants.as_slice());
             quote! {
                 impl FromPositionalRow for #container_identity {
-                    fn from_positional_row(row: &str) -> Result<Self, Box<dyn std::error::Error>> where Self: Sized {
+                    fn from_positional_row(row: &str) -> ::positional::PositionalResult<Self> {
                         #(#variants_stream)*
-                        Err(Box::new(positional::PositionalError::UnparsableFile))
+                        Err(::positional::PositionalError::UnparsableFile)
                     }
                 }
             }

--- a/positional_derive/src/codegen/from_struct.rs
+++ b/positional_derive/src/codegen/from_struct.rs
@@ -25,7 +25,7 @@ pub fn codegen_struct(ir: StructIr, impl_block_type: ImplBlockType) -> Rust {
     match impl_block_type {
         ImplBlockType::From => {
             quote! {
-                impl FromPositionalRow for #container_identity {
+                impl ::positional::FromPositionalRow for #container_identity {
                     fn from_positional_row(row: &str) -> ::positional::PositionalResult<Self> {
                         if row.len() < #offset {
                             return Err(::positional::PositionalError::RowSizeError(#offset, row.to_string()));
@@ -39,7 +39,7 @@ pub fn codegen_struct(ir: StructIr, impl_block_type: ImplBlockType) -> Rust {
         }
         ImplBlockType::To => {
             quote! {
-                impl ToPositionalRow for #container_identity {
+                impl ::positional::ToPositionalRow for #container_identity {
                     fn to_positional_row(&self) -> String {
                         vec![#(#fields_stream),*].into_iter().map(|field| field.to_string()).collect::<Vec<String>>().join("")
                     }
@@ -56,11 +56,11 @@ fn generate_to_field(field: &Field) -> TokenStream {
     let align = &field.attributes.align;
     if field.optional {
         quote! {
-            positional::PositionalField::new(self.#field_ident.as_ref(), #size, #filler, #align)
+            ::positional::PositionalField::new(self.#field_ident.as_ref(), #size, #filler, #align)
         }
     } else {
         quote! {
-            positional::PositionalField::new(Some(&self.#field_ident), #size, #filler, #align)
+            ::positional::PositionalField::new(Some(&self.#field_ident), #size, #filler, #align)
         }
     }
 }
@@ -72,13 +72,13 @@ fn generate_from_field(field: &Field, offset: usize) -> TokenStream {
     let align = &field.attributes.align;
     if field.optional {
         quote! {
-            #field_ident: positional::PositionalParsedField::new(row, #offset, #size, #filler, #align).to_value().parse().ok()
+            #field_ident: ::positional::PositionalParsedField::new(row, #offset, #size, #filler, #align).to_value().parse().ok()
         }
     } else {
         let field_name_string = field_ident.to_string();
         quote! {
-            #field_ident: positional::PositionalParsedField::new(row, #offset, #size, #filler, #align).to_value().parse()
-                .map_err(|_e| positional::PositionalError::ParsingFailed{
+            #field_ident: ::positional::PositionalParsedField::new(row, #offset, #size, #filler, #align).to_value().parse()
+                .map_err(|_e| ::positional::PositionalError::ParsingFailed{
                     // Optimally, we'd pass some information from `_e` into the error;
                     // however, since fields only require a FromStr impl for parsing the data,
                     // the Error type is unrestricted, meaning we can't even extract an error message out of it.


### PR DESCRIPTION
Added a new error variant to handle parsing errors.
Adjusted the necessary generated code and improved macro hygiene.
Adjusted tests.
Removed glob imports, partially to test that macros generate clean code (fully qualified imports).
Fixes [#21](https://github.com/primait/positional.rs/issues/21).