### PR TITLE
Fully qualified imports and name clash tests for generated enum code.

### DIFF
--- a/positional/benches/enum.rs
+++ b/positional/benches/enum.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use criterion::{criterion_group, criterion_main, Criterion};
 use fake::{Fake, Faker};
-use positional::{FromPositionalRow, ToPositionalRow};
+use positional::{FromPositionalRow, ToPositionalRow, Writer};
 
 #[derive(FromPositionalRow, ToPositionalRow, Debug)]
 struct Data {

--- a/positional/tests/name_clashes.rs
+++ b/positional/tests/name_clashes.rs
@@ -23,7 +23,7 @@ impl Data {
     }
 
     #[allow(dead_code)]
-    fn to_positional_row(self) -> String {
+    fn to_positional_row(&self) -> String {
         unreachable!()
     }
 }
@@ -38,8 +38,64 @@ impl Data {
     }
 }
 
+#[derive(Debug, PartialEq, ::positional::FromPositionalRow, ::positional::ToPositionalRow)]
+struct JohnData {
+    #[field(size = 10)]
+    name: String,
+}
+
+#[derive(Debug, PartialEq, ::positional::FromPositionalRow, ::positional::ToPositionalRow)]
+struct PaulData {
+    #[field(size = 10)]
+    name: String,
+}
+
+#[derive(Debug, PartialEq, ::positional::FromPositionalRow, ::positional::ToPositionalRow)]
+enum Beatles {
+    #[matcher(&row[0..=3] == "john")]
+    John(JohnData),
+    #[matcher(&row[0..=3] == "paul")]
+    Paul(PaulData),
+}
+
+impl JohnData {
+    #[allow(dead_code)]
+    fn from_positional_row(_: &str) -> Self {
+        unreachable!()
+    }
+
+    #[allow(dead_code)]
+    fn to_positional_row(&self) -> String {
+        unreachable!()
+    }
+}
+
+impl PaulData {
+    #[allow(dead_code)]
+    fn from_positional_row(_: &str) -> Self {
+        unreachable!()
+    }
+
+    #[allow(dead_code)]
+    fn to_positional_row(&self) -> String {
+        unreachable!()
+    }
+}
+
+impl Beatles {
+    #[allow(dead_code)]
+    fn from_positional_row(_: &str) -> Self {
+        unreachable!()
+    }
+
+    #[allow(dead_code)]
+    fn to_positional_row(&self) -> String {
+        unreachable!()
+    }
+}
+
 #[test]
-fn parse() {
+fn struct_parse_no_name_clashes() {
     let row =
         ::positional::FromPositionalRow::from_positional_row("1    ---10the address is this ")
             .expect("error converting from positional row");
@@ -47,10 +103,39 @@ fn parse() {
 }
 
 #[test]
-fn ser_de() {
+fn struct_ser_de_no_name_clashes() {
     let data = Data::new(1, 100, "the address is this");
     let row = ::positional::ToPositionalRow::to_positional_row(&data);
     let original_data: Data = ::positional::FromPositionalRow::from_positional_row(&row)
         .expect("error converting from positional row");
     assert_eq!(original_data, data);
+}
+
+#[test]
+fn enum_no_name_clashes() {
+    // Parsing
+    let john_data = Beatles::John(JohnData {
+        name: "john".to_string(),
+    });
+    let paul_data = Beatles::Paul(PaulData {
+        name: "paul".to_string(),
+    });
+    let row_john = "john      ";
+    let row_paul = "paul      ";
+
+    let row_wrong = "xxxx      ";
+
+    assert_eq!(
+        <Beatles as ::positional::FromPositionalRow>::from_positional_row(row_john).unwrap(),
+        john_data
+    );
+    assert_eq!(
+        <Beatles as ::positional::FromPositionalRow>::from_positional_row(row_paul).unwrap(),
+        paul_data
+    );
+    assert!(<Beatles as ::positional::FromPositionalRow>::from_positional_row(row_wrong).is_err());
+
+    // Serializing
+    let writer = ::positional::Writer::new(vec![john_data, paul_data]);
+    assert_eq!("john      \npaul      ", writer.to_string());
 }

--- a/positional_derive/src/codegen/from_enum.rs
+++ b/positional_derive/src/codegen/from_enum.rs
@@ -41,7 +41,7 @@ fn create_variants_for_from_positional_row(variants: &[Variant]) -> Vec<proc_mac
         let sub_variant = variant.sub_variant_type.clone();
         let stream = quote! {
             if #expr {
-                return Ok(Self::#ident(#sub_variant::from_positional_row(row)?));
+                return Ok(Self::#ident(<#sub_variant as ::positional::FromPositionalRow>::from_positional_row(row)?));
             }
         };
         variants_stream.push(stream);
@@ -54,7 +54,7 @@ fn create_variants_for_to_positional_row(variants: &[Variant]) -> Vec<proc_macro
     for variant in variants {
         let ident = variant.ident.ident.clone();
         let stream = quote! {
-            Self::#ident(sub_variant) => sub_variant.to_positional_row()
+            Self::#ident(sub_variant) => ::positional::ToPositionalRow::to_positional_row(sub_variant)
         };
         variants_stream.push(stream);
     }


### PR DESCRIPTION
Tested with
- cargo make test
- cargo make bench

Fixed an import in a bench file.

The additional name clash tests gate against regressions for the generated enum code, and they fail for the current state of the code in master.

Fixes [#22](https://github.com/primait/positional.rs/issues/22)