### PR TITLE
CIs update rust version to 1.78 today. Fix error

### DIFF
--- a/positional/src/field.rs
+++ b/positional/src/field.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use pad::{Alignment, PadStr};
 
 #[doc(hidden)]
@@ -46,9 +47,9 @@ impl PositionalField {
     }
 }
 
-impl ToString for PositionalField {
-    fn to_string(&self) -> String {
-        self.value.pad(self.size, self.filler, self.alignment, true)
+impl Display for PositionalField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value.pad(self.size, self.filler, self.alignment, true))
     }
 }
 

--- a/positional/src/field.rs
+++ b/positional/src/field.rs
@@ -1,5 +1,5 @@
-use std::fmt::Display;
 use pad::{Alignment, PadStr};
+use std::fmt::Display;
 
 #[doc(hidden)]
 
@@ -49,7 +49,11 @@ impl PositionalField {
 
 impl Display for PositionalField {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.value.pad(self.size, self.filler, self.alignment, true))
+        write!(
+            f,
+            "{}",
+            self.value.pad(self.size, self.filler, self.alignment, true)
+        )
     }
 }
 


### PR DESCRIPTION
Yesterday the CI run with 1.77. Today master branch run with 1.78 and a lint error occurred:

```
error: direct implementation of `ToString`
  --> positional/src/field.rs:49:1
   |
49 | / impl ToString for PositionalField {
50 | |     fn to_string(&self) -> String {
51 | |         self.value.pad(self.size, self.filler, self.alignment, true)
52 | |     }
53 | | }
   | |_^
```