### PR TITLE
Replace `proc-macro-error` with `proc-macro-error2`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.vscode
 /target
 /Cargo.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- replace the proc-macro-error dependency with proc-macro-error2
+
 ## [0.4.2]
 
 ### Changed

--- a/positional_derive/Cargo.toml
+++ b/positional_derive/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/positional"
 proc-macro = true
 
 [dependencies]
-proc-macro-error = "1.0.4"
+proc-macro-error2 = "2.0"
 proc-macro2 = "1.0.39"
 quote = "1.0"
 syn = {version = "2.0.63", features = ["extra-traits", "full"]}

--- a/positional_derive/src/analyze.rs
+++ b/positional_derive/src/analyze.rs
@@ -1,4 +1,4 @@
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use syn::{Data, DataStruct, Fields};
 
 mod field;

--- a/positional_derive/src/analyze/field.rs
+++ b/positional_derive/src/analyze/field.rs
@@ -1,4 +1,4 @@
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use syn::{LitChar, LitInt, LitStr};
 
 const FIELD_ATTRIBUTE: &str = "field";

--- a/positional_derive/src/analyze/variant.rs
+++ b/positional_derive/src/analyze/variant.rs
@@ -1,4 +1,4 @@
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use syn::{Expr, Fields};
 
 const MATCHER_ATTRIBUTE: &str = "matcher";

--- a/positional_derive/src/lib.rs
+++ b/positional_derive/src/lib.rs
@@ -1,5 +1,5 @@
 use proc_macro::TokenStream;
-use proc_macro_error::proc_macro_error;
+use proc_macro_error2::proc_macro_error;
 
 mod analyze;
 mod codegen;

--- a/positional_derive/src/lower/from_struct.rs
+++ b/positional_derive/src/lower/from_struct.rs
@@ -1,6 +1,6 @@
 use super::extract_option_type;
 use crate::analyze::{FieldAlignment, StructModel};
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 
 pub struct StructIr {
     pub container_identity: syn::Ident,

--- a/positional_derive/src/parse.rs
+++ b/positional_derive/src/parse.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use syn::{Data, DeriveInput};
 
 pub type Ast = DeriveInput;


### PR DESCRIPTION
Fixes #72.

Would be nice to make a new patch-level release of the library once this is merged.