### PR TITLE
feat: use `manyhow` in place of `proc-macro-error2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to
 
 ---
 
+## [0.4.6] - 2026-07-14
+
+# Changed
+
+- Migrate from `proc-macro-error2` to `manyhow`
+
+---
+
 ## [0.4.5] - 2025-09-30
 
 ---
@@ -84,6 +92,7 @@ and this project adheres to
 
 
 [Unreleased]: https://github.com/primait/positional.rs/compare/0.4.5...HEAD
+[0.4.6]: https://github.com/primait/positional.rs/compare/0.4.5...0.4.6
 [0.4.5]: https://github.com/primait/positional.rs/compare/0.4.4...0.4.5
 [0.4.4]: https://github.com/primait/positional.rs/compare/0.4.3...0.4.4
 [0.4.3]: https://github.com/primait/positional.rs/compare/0.4.2...0.4.3

--- a/positional/Cargo.toml
+++ b/positional/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT"
 name = "positional"
 readme = "../README.md"
 repository = "https://github.com/primait/positional.rs"
-version = "0.4.5"
+version = "0.4.6"
 
 [[bench]]
 harness = false
@@ -22,7 +22,7 @@ name = "enum"
 [dependencies]
 itertools = "0.14.0"
 pad = "0.1.6"
-positional_derive = {version = "=0.4.5", path = "../positional_derive"}
+positional_derive = { version = "=0.4.6", path = "../positional_derive" }
 proc-macro2 = "1.0.39"
 quote = "1.0"
 thiserror = "2.0.9"

--- a/positional_derive/Cargo.toml
+++ b/positional_derive/Cargo.toml
@@ -3,7 +3,7 @@ description = "Macros for positional crate"
 edition = "2021"
 license = "MIT"
 name = "positional_derive"
-version = "0.4.5"
+version = "0.4.6"
 documentation = "https://docs.rs/positional"
 
 [lib]

--- a/positional_derive/Cargo.toml
+++ b/positional_derive/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/positional"
 proc-macro = true
 
 [dependencies]
-proc-macro-error2 = "2.0"
+manyhow = "0.11.4"
 proc-macro2 = "1.0.39"
 quote = "1.0"
 syn = {version = "2.0.63", features = ["extra-traits", "full"]}

--- a/positional_derive/src/analyze.rs
+++ b/positional_derive/src/analyze.rs
@@ -1,4 +1,4 @@
-use proc_macro_error2::abort;
+use manyhow::{bail, Result};
 use syn::{Data, DataStruct, Fields};
 
 mod field;
@@ -29,13 +29,13 @@ pub struct EnumModel {
     pub variants: Vec<Variant>,
 }
 
-pub fn analyze(ast: Ast) -> Model {
+pub fn analyze(ast: Ast) -> Result<Model> {
     match ast.data {
         Data::Struct(DataStruct {
             fields: Fields::Unnamed(ref fields_unnamed),
             ..
         }) => {
-            abort!(
+            bail!(
                 fields_unnamed,
                 "only structs with named fields";
                 help = "`#[derive(ToPositionalRow)]` can only be used on structs with named fields, this is a struct with unnamed fields"
@@ -45,7 +45,7 @@ pub fn analyze(ast: Ast) -> Model {
             fields: Fields::Unit,
             ..
         }) => {
-            abort!(
+            bail!(
                 ast,
                 "only structs with named fields";
                 help = "`#[derive(ToPositionalRow)]` can only be used on structs with named fields, this is a unit struct"
@@ -54,30 +54,31 @@ pub fn analyze(ast: Ast) -> Model {
         Data::Enum(data_enum) => {
             let mut variants = vec![];
             for syn_variant in data_enum.variants {
-                match Variant::new(syn_variant.clone()) {
-                    None => abort!(syn_variant, "only enum variants with one unnamed field"),
+                match Variant::new(syn_variant.clone())? {
+                    None => bail!(syn_variant, "only enum variants with one unnamed field"),
                     Some(v) => variants.push(v),
                 }
             }
 
-            Model::Enum(EnumModel {
+            Ok(Model::Enum(EnumModel {
                 container_identity: ast.ident,
                 variants,
-            })
+            }))
         }
         Data::Struct(DataStruct {
             fields: Fields::Named(fields_named),
             ..
         }) => {
-            let fields = fields_named
-                .named
-                .into_iter()
-                .filter_map(Field::new)
-                .collect();
-            Model::Struct(StructModel {
+            let mut fields = vec![];
+            for field in fields_named.named {
+                if let Some(field) = Field::new(field)? {
+                    fields.push(field);
+                }
+            }
+            Ok(Model::Struct(StructModel {
                 container_identity: ast.ident,
                 fields,
-            })
+            }))
         }
         // this is blocked at the parsing phase
         Data::Union(_) => unreachable!(),

--- a/positional_derive/src/analyze/field.rs
+++ b/positional_derive/src/analyze/field.rs
@@ -1,4 +1,4 @@
-use proc_macro_error2::abort;
+use manyhow::{bail, Result};
 use syn::{LitChar, LitInt, LitStr};
 
 const FIELD_ATTRIBUTE: &str = "field";
@@ -11,27 +11,32 @@ pub struct Field {
 }
 
 impl Field {
-    pub fn new(field: syn::Field) -> Option<Self> {
-        parse_field_attributes(&field).map(|(size, filler, align)| Self {
-            field,
-            size,
-            filler,
-            align,
-        })
+    pub fn new(field: syn::Field) -> Result<Option<Self>> {
+        Ok(
+            parse_field_attributes(&field)?.map(|(size, filler, align)| Self {
+                field,
+                size,
+                filler,
+                align,
+            }),
+        )
     }
 }
 
-fn parse_field_attributes(field: &syn::Field) -> Option<(LitInt, Option<LitChar>, Option<LitStr>)> {
+fn parse_field_attributes(
+    field: &syn::Field,
+) -> Result<Option<(LitInt, Option<LitChar>, Option<LitStr>)>> {
     field
         .attrs
         .iter()
         .find(|attribute| attribute.path().is_ident(FIELD_ATTRIBUTE))
         .map(parse_field_attribute_meta)
+        .transpose()
 }
 
 fn parse_field_attribute_meta(
     attribute: &syn::Attribute,
-) -> (LitInt, Option<LitChar>, Option<LitStr>) {
+) -> Result<(LitInt, Option<LitChar>, Option<LitStr>)> {
     let mut size: Option<LitInt> = None;
     let mut align: Option<LitStr> = None;
     let mut filler: Option<LitChar> = None;
@@ -50,12 +55,12 @@ fn parse_field_attribute_meta(
     });
 
     if let Err(err) = parse_result {
-        abort!(err.span(), "failed to parse field attribute"; note = err.to_string());
+        bail!(err.span(), "failed to parse field attribute. {err}");
     }
 
     match size {
-        Some(size) => (size, filler, align),
-        None => abort!(
+        Some(size) => Ok((size, filler, align)),
+        None => bail!(
             attribute,
             "wrong field configuration";
             help = "you need to provide at least a size configuration to the field"

--- a/positional_derive/src/analyze/field.rs
+++ b/positional_derive/src/analyze/field.rs
@@ -23,6 +23,7 @@ impl Field {
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn parse_field_attributes(
     field: &syn::Field,
 ) -> Result<Option<(LitInt, Option<LitChar>, Option<LitStr>)>> {

--- a/positional_derive/src/analyze/variant.rs
+++ b/positional_derive/src/analyze/variant.rs
@@ -1,4 +1,4 @@
-use proc_macro_error2::abort;
+use manyhow::{bail, Result};
 use syn::{Expr, Fields};
 
 const MATCHER_ATTRIBUTE: &str = "matcher";
@@ -15,14 +15,14 @@ pub struct Matcher {
 }
 
 impl Variant {
-    pub fn new(variant: syn::Variant) -> Option<Self> {
+    pub fn new(variant: syn::Variant) -> Result<Option<Self>> {
         match variant.clone().fields {
             Fields::Named(_) => {
-                abort!(variant, "wrong enum variant"; help = "named variants are not supported")
+                bail!(variant, "wrong enum variant"; help = "named variants are not supported")
             }
             Fields::Unnamed(fields_unnamed) => {
                 if fields_unnamed.unnamed.len() > 1 {
-                    abort!(
+                    bail!(
                         variant,
                         "wrong enum variant";
                         help = "Only one unnamed field (implementing the relative ToPositionalRow/ToPositionalRow trait) is accepted"
@@ -31,41 +31,42 @@ impl Variant {
                 let first_field = fields_unnamed.unnamed.first().cloned();
                 let sub_variant_type = first_field.unwrap().ty;
 
-                match parse_variant_attributes(&variant) {
+                match parse_variant_attributes(&variant)? {
                     None => {
-                        abort!(
+                        bail!(
                             variant,
                             "matcher missing";
                             help = "You need to define a matcher for every enum variant. Like #[matcher(row[0..2] == \"00\")]"
                         )
                     }
-                    Some(matcher) => Some(Self {
+                    Some(matcher) => Ok(Some(Self {
                         variant,
                         sub_variant_type,
                         matcher,
-                    }),
+                    })),
                 }
             }
             Fields::Unit => {
-                abort!(variant, "wrong enum variant"; help = "unit variants are not supported")
+                bail!(variant, "wrong enum variant"; help = "unit variants are not supported")
             }
         }
     }
 }
 
-fn parse_variant_attributes(variant: &syn::Variant) -> Option<Matcher> {
+fn parse_variant_attributes(variant: &syn::Variant) -> Result<Option<Matcher>> {
     variant
         .attrs
         .iter()
         .find(|attribute| attribute.path().is_ident(MATCHER_ATTRIBUTE))
         .map(parse_matcher_expression)
+        .transpose()
 }
 
-fn parse_matcher_expression(attribute: &syn::Attribute) -> Matcher {
+fn parse_matcher_expression(attribute: &syn::Attribute) -> Result<Matcher> {
     match attribute.parse_args::<Expr>() {
-        Ok(expr) => Matcher { expr },
+        Ok(expr) => Ok(Matcher { expr }),
         Err(err) => {
-            abort!(
+            bail!(
                 err.span(),
                 "expected an expression as matcher";
                 help = "example syntax: `#[matcher(row[0..2] == \"00\")]`"

--- a/positional_derive/src/lib.rs
+++ b/positional_derive/src/lib.rs
@@ -1,5 +1,6 @@
+use manyhow::manyhow;
 use proc_macro::TokenStream;
-use proc_macro_error2::proc_macro_error;
+use proc_macro2::TokenStream as TokenStream2;
 
 mod analyze;
 mod codegen;
@@ -13,22 +14,22 @@ use parse::{parse, Ast};
 
 /// Add to structs to make them deserializable from positional rows
 #[proc_macro_derive(FromPositionalRow, attributes(field, matcher))]
-#[proc_macro_error]
-pub fn from_positional_row(tokens: TokenStream) -> TokenStream {
-    let ast = parse(tokens.into());
-    let model = analyze(ast);
-    let ir = lower(model);
+#[manyhow]
+pub fn from_positional_row(tokens: TokenStream) -> manyhow::Result<TokenStream2> {
+    let ast = parse(tokens.into())?;
+    let model = analyze(ast)?;
+    let ir = lower(model)?;
     let rust = codegen(ir, ImplBlockType::From);
-    rust.into()
+    Ok(rust)
 }
 
 /// Add to structs to make them serializable into positional rows
 #[proc_macro_derive(ToPositionalRow, attributes(field))]
-#[proc_macro_error]
-pub fn to_positional_row(tokens: TokenStream) -> TokenStream {
-    let ast = parse(tokens.into());
-    let model = analyze(ast);
-    let ir = lower(model);
+#[manyhow]
+pub fn to_positional_row(tokens: TokenStream) -> manyhow::Result<TokenStream2> {
+    let ast = parse(tokens.into())?;
+    let model = analyze(ast)?;
+    let ir = lower(model)?;
     let rust = codegen(ir, ImplBlockType::To);
-    rust.into()
+    Ok(rust)
 }

--- a/positional_derive/src/lower.rs
+++ b/positional_derive/src/lower.rs
@@ -3,6 +3,7 @@ pub mod from_struct;
 
 use super::analyze::Model;
 
+use manyhow::Result;
 use from_enum::{lower_enum, EnumIr};
 use from_struct::{lower_struct, StructIr};
 
@@ -16,10 +17,10 @@ pub enum ImplBlockType {
     To,
 }
 
-pub fn lower(model: Model) -> Ir {
+pub fn lower(model: Model) -> Result<Ir> {
     match model {
-        Model::Struct(struct_model) => Ir::Struct(lower_struct(struct_model)),
-        Model::Enum(enum_model) => Ir::Enum(lower_enum(enum_model)),
+        Model::Struct(struct_model) => Ok(Ir::Struct(lower_struct(struct_model)?)),
+        Model::Enum(enum_model) => Ok(Ir::Enum(lower_enum(enum_model))),
     }
 }
 

--- a/positional_derive/src/lower.rs
+++ b/positional_derive/src/lower.rs
@@ -3,9 +3,9 @@ pub mod from_struct;
 
 use super::analyze::Model;
 
-use manyhow::Result;
 use from_enum::{lower_enum, EnumIr};
 use from_struct::{lower_struct, StructIr};
+use manyhow::Result;
 
 pub enum Ir {
     Struct(StructIr),

--- a/positional_derive/src/lower/from_struct.rs
+++ b/positional_derive/src/lower/from_struct.rs
@@ -1,6 +1,8 @@
-use super::extract_option_type;
+use manyhow::{Result, bail};
+
 use crate::analyze::{FieldAlignment, StructModel};
-use proc_macro_error2::abort;
+
+use super::extract_option_type;
 
 pub struct StructIr {
     pub container_identity: syn::Ident,
@@ -19,16 +21,33 @@ pub struct RowAttributes {
     pub align: FieldAlignment,
 }
 
-pub fn lower_struct(model: StructModel) -> StructIr {
+pub fn lower_struct(model: StructModel) -> Result<StructIr> {
     let mut fields: Vec<Field> = vec![];
     for model_field in model.fields {
+        let align = model_field
+            .align
+            .map(|lit_align| -> Result<FieldAlignment> {
+                let field_align = lit_align.value().parse();
+                match field_align {
+                    Ok(align) => Ok(align),
+                    Err(_) => {
+                        bail!(
+                            lit_align,
+                            "wrong field configuration";
+                            help = "align value should be 'left', 'right', 'l' or 'r'"
+                        )
+                    }
+                }
+            })
+            .unwrap_or(Ok(FieldAlignment::Left))?;
+
         fields.push(Field {
             ident: model_field.field.ident.unwrap(),
             optional: extract_option_type(&model_field.field.ty).is_some(),
             attributes: RowAttributes {
                 size: match model_field.size.base10_parse() {
                     Ok(size) => size,
-                    Err(_) => abort!(
+                    Err(_) => bail!(
                         model_field.size,
                         "wrong field configuration";
                         help = "you need to provide at least a size configuration to the field"
@@ -38,28 +57,13 @@ pub fn lower_struct(model: StructModel) -> StructIr {
                     .filler
                     .map(|lit_filler| lit_filler.value())
                     .unwrap_or(' '),
-                align: model_field
-                    .align
-                    .map(|lit_align| {
-                        let field_align: Result<FieldAlignment, _> = lit_align.value().parse();
-                        match field_align {
-                            Ok(align) => align,
-                            Err(_) => {
-                                abort!(
-                                    lit_align,
-                                    "wrong field configuration";
-                                    help = "align value should be 'left', 'right', 'l' or 'r'"
-                                )
-                            }
-                        }
-                    })
-                    .unwrap_or(FieldAlignment::Left),
+                align,
             },
         })
     }
 
-    StructIr {
+    Ok(StructIr {
         container_identity: model.container_identity,
         fields,
-    }
+    })
 }

--- a/positional_derive/src/lower/from_struct.rs
+++ b/positional_derive/src/lower/from_struct.rs
@@ -1,4 +1,4 @@
-use manyhow::{Result, bail};
+use manyhow::{bail, Result};
 
 use crate::analyze::{FieldAlignment, StructModel};
 

--- a/positional_derive/src/parse.rs
+++ b/positional_derive/src/parse.rs
@@ -1,38 +1,31 @@
+use manyhow::{bail, Result};
 use proc_macro2::TokenStream;
-use proc_macro_error2::abort;
 use syn::{Data, DeriveInput};
 
 pub type Ast = DeriveInput;
 
-pub fn parse(tokens: TokenStream) -> Ast {
-    match syn::parse2::<DeriveInput>(tokens) {
+pub fn parse(tokens: TokenStream) -> Result<Ast> {
+    match syn::parse2::<DeriveInput>(tokens)? {
         // the derivation is applied to a struct
-        Ok(
-            item @ DeriveInput {
-                data: Data::Struct(_),
-                ..
-            },
-        ) => item,
+        item @ DeriveInput {
+            data: Data::Struct(_),
+            ..
+        } => Ok(item),
         // the derivation is applied to an enum
-        Ok(
-            item @ DeriveInput {
-                data: Data::Enum(_),
-                ..
-            },
-        ) => item,
+        item @ DeriveInput {
+            data: Data::Enum(_),
+            ..
+        } => Ok(item),
         // the derivation is applied to a union
-        Ok(
-            item @ DeriveInput {
-                data: Data::Union(_),
-                ..
-            },
-        ) => {
-            abort!(
+        item @ DeriveInput {
+            data: Data::Union(_),
+            ..
+        } => {
+            bail!(
                 item,
                 "item is not a struct or an enum";
                 help = "derives can only be used on structs or enums"
             )
         }
-        Err(_) => unreachable!(),
     }
 }

--- a/positional_derive/src/test/analyze.rs
+++ b/positional_derive/src/test/analyze.rs
@@ -9,7 +9,7 @@ fn can_extract_structs() {
             #[field(size = 20)]
             name: String,
         }
-    ));
+    )).expect("Should be Ok");
     assert!(matches!(model, Model::Struct(_)));
 }
 
@@ -21,6 +21,6 @@ fn can_extract_enums() {
             #[matcher(&row_string[0..=3] == "0000")]
             Row1(RowData1),
         }
-    ));
+    )).expect("Should be Ok");
     assert!(matches!(model, Model::Enum(_)));
 }

--- a/positional_derive/src/test/analyze.rs
+++ b/positional_derive/src/test/analyze.rs
@@ -9,7 +9,8 @@ fn can_extract_structs() {
             #[field(size = 20)]
             name: String,
         }
-    )).expect("Should be Ok");
+    ))
+    .expect("Should be Ok");
     assert!(matches!(model, Model::Struct(_)));
 }
 
@@ -21,6 +22,7 @@ fn can_extract_enums() {
             #[matcher(&row_string[0..=3] == "0000")]
             Row1(RowData1),
         }
-    )).expect("Should be Ok");
+    ))
+    .expect("Should be Ok");
     assert!(matches!(model, Model::Enum(_)));
 }

--- a/positional_derive/tests/ui/list-attributes.stderr
+++ b/positional_derive/tests/ui/list-attributes.stderr
@@ -1,7 +1,4 @@
-error: failed to parse field attribute
-
-         = note: unsupported attribute
-
+error: failed to parse field attribute. unsupported attribute
  --> tests/ui/list-attributes.rs:5:13
   |
 5 |     #[field(a)]

--- a/positional_derive/tests/ui/path-attributes.stderr
+++ b/positional_derive/tests/ui/path-attributes.stderr
@@ -1,7 +1,4 @@
-error: failed to parse field attribute
-
-         = note: expected attribute arguments in parentheses: #[field(...)]
-
+error: failed to parse field attribute. expected attribute arguments in parentheses: #[field(...)]
  --> tests/ui/path-attributes.rs:5:7
   |
 5 |     #[field]

--- a/positional_derive/tests/ui/wrong-filler-type.stderr
+++ b/positional_derive/tests/ui/wrong-filler-type.stderr
@@ -1,7 +1,4 @@
-error: failed to parse field attribute
-
-         = note: expected character literal
-
+error: failed to parse field attribute. expected character literal
  --> tests/ui/wrong-filler-type.rs:5:33
   |
 5 |     #[field(size = 10, filler = "a")]


### PR DESCRIPTION
Replaces `proc-macro-error2` with `manyhow` due to the maintenance issue present.

`manyhow` uses an API highly inspired on `anyhow` so we now have widely use of `Result<_>`
and replacements of `abort!` with `bail!`. Errors are now propagated instead of interrupting
the macro parsing.

Changes in snapshots are purely format related. For instance:

```
EXPECTED:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: failed to parse field attribute

         = note: expected character literal

 --> tests/ui/wrong-filler-type.rs:5:33
  |
5 |     #[field(size = 10, filler = "a")]
  |                                 ^^^
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

ACTUAL OUTPUT:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: failed to parse field attribute. expected character literal
 --> tests/ui/wrong-filler-type.rs:5:33
  |
5 |     #[field(size = 10, filler = "a")]
  |                                 ^^^
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
```

```
EXPECTED:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: failed to parse field attribute

         = note: expected attribute arguments in parentheses: #[field(...)]

 --> tests/ui/path-attributes.rs:5:7
  |
5 |     #[field]
  |       ^^^^^
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

ACTUAL OUTPUT:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: failed to parse field attribute. expected attribute arguments in parentheses: #[field(...)]
 --> tests/ui/path-attributes.rs:5:7
  |
5 |     #[field]
  |       ^^^^^
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
```

```
EXPECTED:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: failed to parse field attribute

         = note: unsupported attribute

 --> tests/ui/list-attributes.rs:5:13
  |
5 |     #[field(a)]
  |             ^
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

ACTUAL OUTPUT:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: failed to parse field attribute. unsupported attribute
 --> tests/ui/list-attributes.rs:5:13
  |
5 |     #[field(a)]
  |             ^
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
```

This is due to the way how `manyhow::bail` prints their output.