### PR TITLE
chore: bump version to `v0.4.7`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@
 This is a library for authoring and parsing positional files
 
 [RustDoc](https://docs.rs/positional)
+
+## Release
+
+For releasing we have a manual approach that involves editing the `Cargo.toml` files.
+Both crates matches (`positional`, `positional_derive`) the same version.
+
+1. Bump the version in both `Cargo.toml`s.
+  a. `positional/Cargo.toml`
+  b. `positional_derive/Cargo.toml`
+2. Commit and push the changes
+3. Open a PR
+4. Create a GitHub release matching same tag

--- a/positional/Cargo.toml
+++ b/positional/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT"
 name = "positional"
 readme = "../README.md"
 repository = "https://github.com/primait/positional.rs"
-version = "0.4.6"
+version = "0.4.7"
 
 [[bench]]
 harness = false

--- a/positional_derive/Cargo.toml
+++ b/positional_derive/Cargo.toml
@@ -3,7 +3,7 @@ description = "Macros for positional crate"
 edition = "2021"
 license = "MIT"
 name = "positional_derive"
-version = "0.4.6"
+version = "0.4.7"
 documentation = "https://docs.rs/positional"
 
 [lib]


### PR DESCRIPTION
- Bumps version prior to release
- Update README.md following